### PR TITLE
Replaced DispatchQueue with Swift concurrency

### DIFF
--- a/Cool Loaders/ContentView.swift
+++ b/Cool Loaders/ContentView.swift
@@ -80,20 +80,17 @@ struct ContentView: View {
             
             if let loaderContent = loaderContent {
                 CustomNavigationView(loaderType: loaderContent) {
-                    DispatchQueue.main.asyncAfter(deadline: .now()) {
-                        withAnimation{
-                            self.detailOffset = UIScreen.main.bounds.width
-                        }
-                    }
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                        self.loaderContent = nil
-                    }
-                   
+                  Task { @MainActor in
+                      withAnimation {
+                          self.detailOffset = UIScreen.main.bounds.width
+                      }
+                    try await Task.sleep(for: .seconds(0.1))
+                    self.loaderContent = nil
+                  }
                 }
                 .onAppear{
-                    withAnimation{
+                    withAnimation {
                         self.detailOffset = 0
-                        
                     }
                 }
                 .offset(x: detailOffset)
@@ -113,14 +110,12 @@ struct ContentView: View {
                             HStack(spacing: 20){
                                 ZStack{
                                     WrapperView(loader: .ring) { loaderContent  in
-                                        DispatchQueue.main.asyncAfter(deadline: .now()) {
+                                        Task { @MainActor in
                                             withAnimation{
                                                 self.homeOffset = -UIScreen.main.bounds.width
                                             }
-                                        }
-                                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                                                self.loaderContent = loaderContent
-                                            
+                                            try await Task.sleep(for: .seconds(0.1))
+                                            self.loaderContent = loaderContent
                                         }
                                     }
                                     .scaleEffect(0.5)
@@ -133,14 +128,12 @@ struct ContentView: View {
                                     }
                                 ZStack{
                                     WrapperView(loader: .rings) { loaderContent  in
-                                        DispatchQueue.main.asyncAfter(deadline: .now()) {
+                                        Task { @MainActor in
                                             withAnimation{
                                                 self.homeOffset = -UIScreen.main.bounds.width
                                             }
-                                        }
-                                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                                                self.loaderContent = loaderContent
-                                            
+                                            try await Task.sleep(for: .seconds(0.1))
+                                            self.loaderContent = loaderContent
                                         }
                                     }
                                     .scaleEffect(0.4)
@@ -156,14 +149,12 @@ struct ContentView: View {
                             HStack(spacing: 20){
                                 ZStack{
                                     WrapperView(loader: .space) { loaderContent  in
-                                        DispatchQueue.main.asyncAfter(deadline: .now()) {
+                                        Task { @MainActor in
                                             withAnimation{
                                                 self.homeOffset = -UIScreen.main.bounds.width
                                             }
-                                        }
-                                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                                                self.loaderContent = loaderContent
-                                            
+                                            try await Task.sleep(for: .seconds(0.1))
+                                            self.loaderContent = loaderContent
                                         }
                                     }
                                     .scaleEffect(0.52)
@@ -175,14 +166,12 @@ struct ContentView: View {
                                     }
                                 ZStack{
                                     WrapperView(loader: .wheel) { loaderContent  in
-                                        DispatchQueue.main.asyncAfter(deadline: .now()) {
+                                        Task { @MainActor in
                                             withAnimation{
                                                 self.homeOffset = -UIScreen.main.bounds.width
                                             }
-                                        }
-                                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                                                self.loaderContent = loaderContent
-                                            
+                                            try await Task.sleep(for: .seconds(0.1))
+                                            self.loaderContent = loaderContent
                                         }
                                     }
                                     .scaleEffect(0.4)
@@ -197,14 +186,12 @@ struct ContentView: View {
                             HStack(spacing: 20){
                                 ZStack{
                                     WrapperView(loader: .track) { loaderContent  in
-                                        DispatchQueue.main.asyncAfter(deadline: .now()) {
+                                        Task { @MainActor in
                                             withAnimation{
                                                 self.homeOffset = -UIScreen.main.bounds.width
                                             }
-                                        }
-                                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                                                self.loaderContent = loaderContent
-                                            
+                                            try await Task.sleep(for: .seconds(0.1))
+                                            self.loaderContent = loaderContent
                                         }
                                     }
                                     .scaleEffect(0.52)
@@ -217,14 +204,12 @@ struct ContentView: View {
                                     }
                                 ZStack{
                                     WrapperView(loader: .leaf) { loaderContent  in
-                                        DispatchQueue.main.asyncAfter(deadline: .now()) {
+                                        Task { @MainActor in
                                             withAnimation{
                                                 self.homeOffset = -UIScreen.main.bounds.width
                                             }
-                                        }
-                                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                                                self.loaderContent = loaderContent
-                                            
+                                            try await Task.sleep(for: .seconds(0.1))
+                                            self.loaderContent = loaderContent
                                         }
                                     }
                                     .scaleEffect(0.52)
@@ -240,14 +225,12 @@ struct ContentView: View {
                             HStack{
                                 ZStack{
                                     WrapperView(loader: .bar) { loaderContent  in
-                                        DispatchQueue.main.asyncAfter(deadline: .now()) {
+                                        Task { @MainActor in
                                             withAnimation{
                                                 self.homeOffset = -UIScreen.main.bounds.width
                                             }
-                                        }
-                                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                                                self.loaderContent = loaderContent
-                                            
+                                            try await Task.sleep(for: .seconds(0.1))
+                                            self.loaderContent = loaderContent
                                         }
                                     }.scaleEffect(1)
                                         .frame(width: 400, height: 80)

--- a/Cool Loaders/LoaderView/Bar.swift
+++ b/Cool Loaders/LoaderView/Bar.swift
@@ -63,11 +63,9 @@ struct Bar: View {
                 }
                 .offset(x: xOffset)
                 .onAppear {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                        withAnimation(.linear(duration: 2).repeatForever(autoreverses: false)) {
-                            xOffset = 500
-                        }
-                    }
+                  withAnimation(.linear(duration: 2).delay(0.1).repeatForever(autoreverses: false)) {
+                      xOffset = 500
+                  }
                 }
             }
             //Color masking
@@ -129,22 +127,23 @@ struct Bar: View {
         }
     }
     func performAnimation() {
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            withAnimation(.linear(duration: 0.2)) {
-                self.animationState = 2
-            }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                withAnimation(.linear(duration: 0.2)) {
-                    self.animationState = 3
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                        // Instantly transition to frame 1 without animation
-                        self.animationState = 1
-                        performAnimation() // Repeat the animation
-                    }
-                }
-            }
+      Task { @MainActor in
+        try await Task.sleep(for: .seconds(1))
+        withAnimation(.linear(duration: 0.2)) {
+            self.animationState = 2
         }
+        try await Task.sleep(for: .seconds(1))
+        withAnimation(.linear(duration: 0.2)) {
+            self.animationState = 3
+        }
+        try await Task.sleep(for: .seconds(1))
+        withAnimation(.linear(duration: 0.2)) {
+          // Instantly transition to frame 1 without animation
+          self.animationState = 1
+
+        }
+        performAnimation() // Repeat the animation
+      }
     }
     
 }

--- a/Cool Loaders/LoaderView/Leaf.swift
+++ b/Cool Loaders/LoaderView/Leaf.swift
@@ -67,12 +67,13 @@ struct Leaf: View {
                 }
             }
             .offset(x: -48)
-            .onAppear {
-                
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
-                    
-                    animateCircles(rev: false, cBool: true)
-                }
+            .task {
+              do {
+                try await Task.sleep(for: .seconds(0.4))
+                animateCircles(rev: false, cBool: true)
+              } catch {
+                print(error)
+              }
             }
             
             ZStack{
@@ -85,25 +86,30 @@ struct Leaf: View {
                     }
                     
                 }
-            }.onAppear{
-                
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
-                    
-                    animateCircles(rev: true, cBool: false)
-                }
+            }
+            .task {
+              do {
+                try await Task.sleep(for: .seconds(0.4))
+                animateCircles(rev: true, cBool: false)
+              } catch {
+                print(error)
+              }
             }
             .offset(x: -48).scaleEffect(x: -1, y: 1)
             
             
-        }.scaleEffect(1.8)
-            .onAppear {
-                
-                
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                    
-                }
-                
+        }
+        .scaleEffect(1.8)
+        .task {
+
+            do {
+              try await Task.sleep(for: .seconds(2))
+              // missing code?
+            } catch {
+              print(error)
             }
+
+        }
             .onDisappear {
                 refreshManager.shouldRefresh = true
             }
@@ -123,27 +129,26 @@ struct Leaf: View {
             
             
             if index < circles.count - 1 {
-                DispatchQueue.main.asyncAfter(deadline: .now() ) {
-                    withAnimation(Animation.linear(duration: 0.7)) {
-                        
-                        if rev {
-                            shiftLeft(cBool: cBool)
-                        } else {
-                            shiftRight(cBool: cBool)
-                        }
-                        
-                    }
-                }
-                
+              withAnimation(Animation.linear(duration: 0.7)) {
+
+                  if rev {
+                      shiftLeft(cBool: cBool)
+                  } else {
+                      shiftRight(cBool: cBool)
+                  }
+
+              }
+
             }
             
             index += 1
             
         }
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
-            self.animateCircles(rev: rev, cBool: cBool)
-        }
+      Task { @MainActor in
+        try await Task.sleep(for: .seconds(0.7))
+        self.animateCircles(rev: rev, cBool: cBool)
+      }
+
     }
     
     
@@ -205,9 +210,10 @@ struct Leaf: View {
     }
     
     func changeOpacity(idx: Int) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            self.circles[idx].opacity = 0
-        }
+      Task { @MainActor in
+        try await Task.sleep(for: .seconds(2))
+        self.circles[idx].opacity = 0
+      }
     }
     func resetCircleProperties() {
         //        self.circles[idx].position = pos
@@ -217,11 +223,13 @@ struct Leaf: View {
     }
     
     func animateLastCircle(withDelay delay: TimeInterval, index: Int, pos: CGFloat) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            self.circles[index].opacity = 0
-            self.circles[index].position = pos
-        }
-        
+      Task { @MainActor in
+        try await Task.sleep(until: .now + .seconds(0.1),
+                             tolerance: .microseconds(1),
+                             clock: .continuous)
+        self.circles[index].opacity = 0
+        self.circles[index].position = pos
+      }
     }
     
     

--- a/Cool Loaders/LoaderView/Ring.swift
+++ b/Cool Loaders/LoaderView/Ring.swift
@@ -106,11 +106,9 @@ struct Ring: View {
                 }
             
         }
-        .onAppear {
+        .task {
 //            refreshID = UUID()
-            DispatchQueue.main.async {
-                rotateShapesContinuously(circleDuration: 12.0, ellipseDuration: 4.0)
-            }
+          rotateShapesContinuously(circleDuration: 12.0, ellipseDuration: 4.0)
 //            resetAll = true
             
         }

--- a/Cool Loaders/LoaderView/Rings.swift
+++ b/Cool Loaders/LoaderView/Rings.swift
@@ -168,10 +168,13 @@ struct Rings: View {
                     .frame(width: geometry.size.width, height: geometry.size.height)
                 }
                 
-                .onAppear {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                        rotateShapesContinuously(circleDuration1: 2.0, circleDuration2: 1.0)
-                    }
+                .task {
+                  do {
+                    try await Task.sleep(for: .seconds(0.1))
+                    rotateShapesContinuously(circleDuration1: 2.0, circleDuration2: 1.0)
+                  } catch {
+                    print(error)
+                  }
                 }
             }
             .frame(width: 300, height: 300)

--- a/Cool Loaders/LoaderView/Space.swift
+++ b/Cool Loaders/LoaderView/Space.swift
@@ -158,10 +158,8 @@ struct Space: View {
                             }
                             .offset(x: xOffset)
                             .onAppear {
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                                    withAnimation(.linear(duration: 2).repeatForever(autoreverses: false)) {
-                                        xOffset = 500
-                                    }
+                                withAnimation(.linear(duration: 2).delay(0.1).repeatForever(autoreverses: false)) {
+                                    xOffset = 500
                                 }
                             }
                         }
@@ -177,10 +175,13 @@ struct Space: View {
                 }
         }
         .background(.clear)
-        .onAppear {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-             
-            }
+        .task {
+          do {
+            try await Task.sleep(for: .seconds(0.1))
+            // missing code?
+          } catch {
+            print(error)
+          }
         }
         .ignoresSafeArea()
     }

--- a/Cool Loaders/LoaderView/Track.swift
+++ b/Cool Loaders/LoaderView/Track.swift
@@ -194,10 +194,8 @@ struct Track: View {
   
             
         }
-        .onAppear {
-            DispatchQueue.main.asyncAfter(deadline: .now() ) {
-                animateStep3() // starting postion from stept 4
-            }
+        .task {
+            animateStep3()
         }
         .onDisappear {
             cleanUpTimer()
@@ -215,48 +213,43 @@ struct Track: View {
     }
     
     func animateStep1() {
-        
-        withAnimation(Animation.linear(duration: 1.0)) {
-            self.rotationDegrees = 180
-            
-        }
-        
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+        Task { @MainActor in
+            withAnimation(Animation.linear(duration: 1.0)) {
+                self.rotationDegrees = 180
+            }
+            try await Task.sleep(for: .seconds(1))
             self.animateStep2()
         }
     }
     
     func animateStep2() {
-        withAnimation(Animation.linear(duration: 1.0)) {
-            self.offsetX = 64
-        }
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+        Task { @MainActor in
+            withAnimation(Animation.linear(duration: 1.0)) {
+                self.offsetX = 64
+            }
+            try await Task.sleep(for: .seconds(1))
             self.animateStep3()
         }
     }
     
     func animateStep3() {
-        withAnimation(Animation.linear(duration: 1.0)) {
-            self.rotationDegrees = 360
-            
-        }
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+        Task { @MainActor in
+            withAnimation(Animation.linear(duration: 1.0)) {
+                self.rotationDegrees = 360
+            }
+            try await Task.sleep(for: .seconds(1))
             self.animateStep4()
         }
     }
     
     func animateStep4() {
-        withAnimation(Animation.linear(duration: 1.0)) {
-            self.offsetX = -64
-        }
-        self.rotationDegrees = 0
-        
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+        Task { @MainActor in
+            withAnimation(Animation.linear(duration: 1.0)) {
+                self.offsetX = -64
+            }
+            self.rotationDegrees = 0
+            try await Task.sleep(for: .seconds(1))
             self.animateSequence()
-            
         }
     }
     

--- a/Cool Loaders/LoaderView/Wheel.swift
+++ b/Cool Loaders/LoaderView/Wheel.swift
@@ -150,10 +150,13 @@ struct Wheel: View {
             }
    
         }
-        .onAppear {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                rotateShapesContinuously(circleDuration: 1.4)
-            }
+        .task {
+          do {
+            try await Task.sleep(for: .seconds(0.1))
+            rotateShapesContinuously(circleDuration: 1.4)
+          } catch {
+            print(error)
+          }
         }
         .ignoresSafeArea()
         

--- a/Cool Loaders/SplashScreenView.swift
+++ b/Cool Loaders/SplashScreenView.swift
@@ -38,31 +38,23 @@ struct SplashScreenView: View {
                         
                     }
                     .onAppear(){
-                        withAnimation(Animation.easeInOut(duration: 1.4).repeatForever()) {
-                            self.gOpacity = self.gOpacity == 1.0 ? 0.6 : 1.0
-                        }
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                            withAnimation(.easeIn(duration: 1.2)) {
-                                self.size = 1.0
-                                self.opacity = 1.0
-                            }
-                        }
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
-                            withAnimation(.easeIn(duration: 0.2)) {
-                                self.rOpacity = 1.0
-                            }
-                        }
-                        
+                      withAnimation(Animation.easeInOut(duration: 1.4).repeatForever()) {
+                          self.gOpacity = self.gOpacity == 1.0 ? 0.6 : 1.0
+                      }
+                      withAnimation(.easeIn(duration: 1.2).delay(0.5)) {
+                          self.size = 1.0
+                          self.opacity = 1.0
+                      }
+                      withAnimation(.easeIn(duration: 0.2).delay(1.2)) {
+                          self.rOpacity = 1.0
+                      }
                     }
                 }
                 .frame(width: geometry.size.width, height: geometry.size.height)
                 .background(Color("LaunchScreenBackgroundColor"))
-                
-                .onAppear(){
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.7){
-                        withAnimation(){
-                            self.isActive = true
-                        }
+                .onAppear {
+                  withAnimation(.default.delay(1.7)){
+                        self.isActive = true
                     }
                 }
             }


### PR DESCRIPTION
This commit replaces the use of old DispatchQueue with new Swift concurrency (Task and async/await).

Concurrency remains unstructured, and some uses of concurrency are questionable. I recommend implementing structured concurrency in the future, and reducing the amount of repetitive code. However, that's not the purpose of this pull request.

This is a first step towards making it possible to make concurrency in the sample project a bit more structured.